### PR TITLE
feat: Docker and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+bin/
+*.test
+*.out
+certs/
+.github/
+*.md
+!README.md
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/sentry-server ./server \
+    && CGO_ENABLED=0 GOOS=linux go build -o /out/sentry ./cmd/cli
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /out/sentry-server /usr/local/bin/
+COPY --from=builder /out/sentry /usr/local/bin/
+
+EXPOSE 50051
+ENTRYPOINT ["/usr/local/bin/sentry-server"]

--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ sentry logs -id <job_id> -force
 sentry list
 ```
 
+## Running with Docker
+
+Place the server certificate, server key, and CA certificate in `certs/`, then start the server with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The compose service runs in privileged mode with host cgroups so the server can manage cgroup resources.
+
 ## Project Layout
 
 ```text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  sentry-server:
+    build: .
+    privileged: true
+    cgroup: host
+    volumes:
+      - ./certs:/certs:ro
+    environment:
+      SENTRY_SERVER_CERT: /certs/server.crt
+      SENTRY_SERVER_KEY: /certs/server.key
+      SENTRY_CA_CERT: /certs/ca.crt
+    ports:
+      - "50051:50051"
+    restart: unless-stopped


### PR DESCRIPTION
Adds Dockerfile, docker-compose configuration, .dockerignore, and README instructions for running the sentry server with Docker.