### PR TITLE
feat: configurable port and cert paths via flags/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,19 @@ bash script/gen_cert.sh
 ### Starting the Server
 
 ```bash
-./bin/sentry-server
+./bin/sentry-server [options]
 ```
 
-The server listens on port 50051 by default and exposes the standard gRPC health service and reflection.
+The server listens on port 50051 by default and exposes the standard gRPC health service and reflection. Options can also be set with environment variables when the corresponding flag is left at its default value.
+
+Options:
+
+```text
+  -port int      Port to listen on (default 50051, env SENTRY_PORT)
+  -cert string   Server certificate path (default "certs/server.crt", env SENTRY_SERVER_CERT)
+  -key string    Server private key path (default "certs/server.key", env SENTRY_SERVER_KEY)
+  -ca string     CA certificate path (default "certs/ca.crt", env SENTRY_CA_CERT)
+```
 
 Probe readiness with mutual TLS:
 
@@ -146,6 +155,17 @@ grpc_health_probe -addr=localhost:50051 -tls -tls-ca-cert ca.crt -tls-client-cer
 ```
 
 ### Using the CLI
+
+The CLI supports global options before the subcommand. Options can also be set with environment variables when the corresponding flag is left at its default value.
+
+Global options:
+
+```text
+  -server string  Sentry server address (default "localhost:50051", env SENTRY_SERVER)
+  -cert string    Client certificate path (default "certs/client.crt", env SENTRY_CLIENT_CERT)
+  -key string     Client private key path (default "certs/client.key", env SENTRY_CLIENT_KEY)
+  -ca string      CA certificate path (default "certs/ca.crt", env SENTRY_CA_CERT)
+```
 
 The CLI supports the following commands:
 
@@ -170,7 +190,10 @@ Options:
 # List all jobs
 sentry list
 
-# Kill a job
+# Stop a job gracefully
+sentry stop -id <job_id>
+
+# Kill a job with SIGKILL
 sentry kill -id <job_id>
 ```
 
@@ -191,6 +214,9 @@ sentry start -cmd /bin/sh -wbps-limit 1048576 -- -c "dd if=/dev/zero of=./sentry
 
 # Monitor job logs in real-time
 sentry logs -id <job_id> -force
+
+# Stop a job gracefully
+sentry stop -id <job_id>
 
 # List all running jobs
 sentry list

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -20,8 +20,43 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: cli <command> [options]")
+	const (
+		defaultServerAddr = "localhost:50051"
+		defaultClientCert = "certs/client.crt"
+		defaultClientKey  = "certs/client.key"
+		defaultCACert     = "certs/ca.crt"
+	)
+
+	globalFlags := flag.NewFlagSet("cli", flag.ExitOnError)
+	serverAddr := globalFlags.String("server", defaultServerAddr, "Sentry server address")
+	clientCertPath := globalFlags.String("cert", defaultClientCert, "Client certificate path")
+	clientKeyPath := globalFlags.String("key", defaultClientKey, "Client private key path")
+	caCertPath := globalFlags.String("ca", defaultCACert, "CA certificate path")
+	globalFlags.Parse(os.Args[1:])
+
+	if *serverAddr == defaultServerAddr {
+		if envServer := os.Getenv("SENTRY_SERVER"); envServer != "" {
+			*serverAddr = envServer
+		}
+	}
+	if *clientCertPath == defaultClientCert {
+		if envCert := os.Getenv("SENTRY_CLIENT_CERT"); envCert != "" {
+			*clientCertPath = envCert
+		}
+	}
+	if *clientKeyPath == defaultClientKey {
+		if envKey := os.Getenv("SENTRY_CLIENT_KEY"); envKey != "" {
+			*clientKeyPath = envKey
+		}
+	}
+	if *caCertPath == defaultCACert {
+		if envCA := os.Getenv("SENTRY_CA_CERT"); envCA != "" {
+			*caCertPath = envCA
+		}
+	}
+
+	if globalFlags.NArg() < 1 {
+		fmt.Println("Usage: cli [global options] <command> [options]")
 		fmt.Println("Commands:")
 		fmt.Println("  start   Start a new job")
 		fmt.Println("  stop    Stop a running job")
@@ -32,8 +67,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	command := os.Args[1]
-	serverAddr := "localhost:50051"
+	command := globalFlags.Arg(0)
+	commandArgs := globalFlags.Args()[1:]
 
 	// Create separate FlagSets for each command
 	startFlags := flag.NewFlagSet("start", flag.ExitOnError)
@@ -73,13 +108,13 @@ func main() {
 	}()
 
 	// Load client certificate and private key
-	clientCert, err := tls.LoadX509KeyPair("certs/client.crt", "certs/client.key")
+	clientCert, err := tls.LoadX509KeyPair(*clientCertPath, *clientKeyPath)
 	if err != nil {
 		log.Fatalf("Failed to load client certificates: %v", err)
 	}
 
 	// Load CA certificate
-	caCert, err := os.ReadFile("certs/ca.crt")
+	caCert, err := os.ReadFile(*caCertPath)
 	if err != nil {
 		log.Fatalf("Failed to load CA certificate: %v", err)
 	}
@@ -97,7 +132,7 @@ func main() {
 	}
 	creds := credentials.NewTLS(tlsConfig)
 
-	conn, err := grpc.NewClient(serverAddr,
+	conn, err := grpc.NewClient(*serverAddr,
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
@@ -109,7 +144,7 @@ func main() {
 
 	switch command {
 	case "start":
-		startFlags.Parse(os.Args[2:])
+		startFlags.Parse(commandArgs)
 		if *startCmd == "" {
 			log.Fatal("Command is required for start action. Use -cmd flag")
 		}
@@ -128,7 +163,7 @@ func main() {
 		}
 		fmt.Printf("Job ID: %v\n", job.JobId)
 	case "status":
-		statusFlags.Parse(os.Args[2:])
+		statusFlags.Parse(commandArgs)
 		if *statusID == "" {
 			log.Fatal("Job ID is required for status action. Use -id flag")
 		}
@@ -146,7 +181,7 @@ func main() {
 		fmt.Printf("Job status: %s\n", status)
 
 	case "logs":
-		logsFlags.Parse(os.Args[2:])
+		logsFlags.Parse(commandArgs)
 		if *logsID == "" {
 			log.Fatal("Job ID is required for logs action. Use -id flag")
 		}
@@ -211,7 +246,7 @@ func main() {
 		}
 
 	case "stop":
-		stopFlags.Parse(os.Args[2:])
+		stopFlags.Parse(commandArgs)
 		if *stopID == "" {
 			log.Fatal("Job ID is required for stop action. Use -id flag")
 		}
@@ -224,7 +259,7 @@ func main() {
 		fmt.Printf("Stop job result: %s\n", resp.Message)
 
 	case "kill":
-		killFlags.Parse(os.Args[2:])
+		killFlags.Parse(commandArgs)
 		if *killID == "" {
 			log.Fatal("Job ID is required for kill action. Use -id flag")
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"flag"
 	"fmt"
 	"log"
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	pb "github.com/arazmj/sentry-run/api/proto"
@@ -23,14 +25,52 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
 	log.SetOutput(os.Stdout)
 
+	const (
+		defaultPort       = 50051
+		defaultServerCert = "certs/server.crt"
+		defaultServerKey  = "certs/server.key"
+		defaultCACert     = "certs/ca.crt"
+	)
+
+	port := flag.Int("port", defaultPort, "Port to listen on")
+	serverCertPath := flag.String("cert", defaultServerCert, "Server certificate path")
+	serverKeyPath := flag.String("key", defaultServerKey, "Server private key path")
+	caCertPath := flag.String("ca", defaultCACert, "CA certificate path")
+	flag.Parse()
+
+	if *port == defaultPort {
+		if envPort := os.Getenv("SENTRY_PORT"); envPort != "" {
+			parsedPort, err := strconv.Atoi(envPort)
+			if err != nil {
+				log.Fatalf("Invalid SENTRY_PORT %q: %v", envPort, err)
+			}
+			*port = parsedPort
+		}
+	}
+	if *serverCertPath == defaultServerCert {
+		if envCert := os.Getenv("SENTRY_SERVER_CERT"); envCert != "" {
+			*serverCertPath = envCert
+		}
+	}
+	if *serverKeyPath == defaultServerKey {
+		if envKey := os.Getenv("SENTRY_SERVER_KEY"); envKey != "" {
+			*serverKeyPath = envKey
+		}
+	}
+	if *caCertPath == defaultCACert {
+		if envCA := os.Getenv("SENTRY_CA_CERT"); envCA != "" {
+			*caCertPath = envCA
+		}
+	}
+
 	// Load server certificate and private key
-	serverCert, err := tls.LoadX509KeyPair("certs/server.crt", "certs/server.key")
+	serverCert, err := tls.LoadX509KeyPair(*serverCertPath, *serverKeyPath)
 	if err != nil {
 		log.Fatalf("Failed to load server certificates: %v", err)
 	}
 
 	// Load CA certificate
-	caCert, err := os.ReadFile("certs/ca.crt")
+	caCert, err := os.ReadFile(*caCertPath)
 	if err != nil {
 		log.Fatalf("Failed to load CA certificate: %v", err)
 	}
@@ -49,8 +89,7 @@ func main() {
 	}
 	creds := credentials.NewTLS(tlsConfig)
 
-	port := 50051
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
@@ -80,7 +119,7 @@ func main() {
 		os.Exit(0)
 	}()
 
-	log.Printf("Server listening on port %d", port)
+	log.Printf("Server listening on port %d", *port)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}


### PR DESCRIPTION
Adds configurable server and CLI port/server/certificate paths via flags with environment variable fallbacks.

Validation:
- GOOS=linux go build ./...
- GOOS=linux go vet ./server ./cmd/cli

Note: GOOS=linux go vet ./... still reports pre-existing pkg/jobmanager/manager.go:155 unreachable code.