### PR TITLE
feat(proto): add StopJob RPC and stop CLI command

### DIFF
--- a/api/proto/sentry.proto
+++ b/api/proto/sentry.proto
@@ -5,6 +5,7 @@ option go_package = "sentry/api/proto";
 
 service SentryService {
   rpc StartJob (StartJobRequest) returns (StartJobResponse)  {}
+  rpc StopJob (StopJobRequest) returns (StopJobResponse) {}
   rpc KillJob (KillJobRequest) returns (KillJobResponse) {}
   rpc GetJobStatus (JobStatusRequest) returns (JobStatusResponse) {}
   rpc StreamJobLogs (JobLogsRequest) returns (stream JobOutput) {}

--- a/api/proto/sentry_grpc.pb.go
+++ b/api/proto/sentry_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	SentryService_StartJob_FullMethodName      = "/sentry.SentryService/StartJob"
+	SentryService_StopJob_FullMethodName       = "/sentry.SentryService/StopJob"
 	SentryService_KillJob_FullMethodName       = "/sentry.SentryService/KillJob"
 	SentryService_GetJobStatus_FullMethodName  = "/sentry.SentryService/GetJobStatus"
 	SentryService_StreamJobLogs_FullMethodName = "/sentry.SentryService/StreamJobLogs"
@@ -31,6 +32,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SentryServiceClient interface {
 	StartJob(ctx context.Context, in *StartJobRequest, opts ...grpc.CallOption) (*StartJobResponse, error)
+	StopJob(ctx context.Context, in *StopJobRequest, opts ...grpc.CallOption) (*StopJobResponse, error)
 	KillJob(ctx context.Context, in *KillJobRequest, opts ...grpc.CallOption) (*KillJobResponse, error)
 	GetJobStatus(ctx context.Context, in *JobStatusRequest, opts ...grpc.CallOption) (*JobStatusResponse, error)
 	StreamJobLogs(ctx context.Context, in *JobLogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobOutput], error)
@@ -49,6 +51,16 @@ func (c *sentryServiceClient) StartJob(ctx context.Context, in *StartJobRequest,
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(StartJobResponse)
 	err := c.cc.Invoke(ctx, SentryService_StartJob_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sentryServiceClient) StopJob(ctx context.Context, in *StopJobRequest, opts ...grpc.CallOption) (*StopJobResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StopJobResponse)
+	err := c.cc.Invoke(ctx, SentryService_StopJob_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,6 +121,7 @@ func (c *sentryServiceClient) ListJobs(ctx context.Context, in *ListJobsRequest,
 // for forward compatibility.
 type SentryServiceServer interface {
 	StartJob(context.Context, *StartJobRequest) (*StartJobResponse, error)
+	StopJob(context.Context, *StopJobRequest) (*StopJobResponse, error)
 	KillJob(context.Context, *KillJobRequest) (*KillJobResponse, error)
 	GetJobStatus(context.Context, *JobStatusRequest) (*JobStatusResponse, error)
 	StreamJobLogs(*JobLogsRequest, grpc.ServerStreamingServer[JobOutput]) error
@@ -125,6 +138,9 @@ type UnimplementedSentryServiceServer struct{}
 
 func (UnimplementedSentryServiceServer) StartJob(context.Context, *StartJobRequest) (*StartJobResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StartJob not implemented")
+}
+func (UnimplementedSentryServiceServer) StopJob(context.Context, *StopJobRequest) (*StopJobResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopJob not implemented")
 }
 func (UnimplementedSentryServiceServer) KillJob(context.Context, *KillJobRequest) (*KillJobResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method KillJob not implemented")
@@ -173,6 +189,24 @@ func _SentryService_StartJob_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(SentryServiceServer).StartJob(ctx, req.(*StartJobRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SentryService_StopJob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopJobRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SentryServiceServer).StopJob(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SentryService_StopJob_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SentryServiceServer).StopJob(ctx, req.(*StopJobRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -252,6 +286,10 @@ var SentryService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "StartJob",
 			Handler:    _SentryService_StartJob_Handler,
+		},
+		{
+			MethodName: "StopJob",
+			Handler:    _SentryService_StopJob_Handler,
 		},
 		{
 			MethodName: "KillJob",

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -51,6 +51,9 @@ func main() {
 	logsID := logsFlags.String("id", "", "Job ID")
 	logsForce := logsFlags.Bool("force", false, "Stream logs in real-time")
 
+	stopFlags := flag.NewFlagSet("stop", flag.ExitOnError)
+	stopID := stopFlags.String("id", "", "Job ID")
+
 	killFlags := flag.NewFlagSet("kill", flag.ExitOnError)
 	killID := killFlags.String("id", "", "Job ID")
 
@@ -206,6 +209,19 @@ func main() {
 				job.JobId, status, job.MemoryLimit, job.CpuLimit,
 				job.WriteBps, job.ReadBps, job.Command)
 		}
+
+	case "stop":
+		stopFlags.Parse(os.Args[2:])
+		if *stopID == "" {
+			log.Fatal("Job ID is required for stop action. Use -id flag")
+		}
+		resp, err := client.StopJob(ctx, &pb.StopJobRequest{
+			JobId: *stopID,
+		})
+		if err != nil {
+			log.Fatalf("Could not stop job: %v", err)
+		}
+		fmt.Printf("Stop job result: %s\n", resp.Message)
 
 	case "kill":
 		killFlags.Parse(os.Args[2:])

--- a/pkg/jobmanager/manager.go
+++ b/pkg/jobmanager/manager.go
@@ -151,9 +151,9 @@ func (m *JobManager) StartJob(command string, commandArgs []string, memoryLimit,
 
 	jobUUID, err := uuid.NewUUID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 		stdout.Close()
 		stderr.Close()
+		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 	}
 	jobID := jobUUID.String()
 


### PR DESCRIPTION
Adds the StopJob RPC to the proto service/client/server bindings and exposes a CLI stop command that calls it.

Validation: GOOS=linux GOARCH=amd64 go build ./...; GOOS=linux GOARCH=amd64 go vet ./...