### PR TITLE
test(jobmanager): add unit tests and skip empty-limit cgroup setup

### DIFF
--- a/pkg/jobmanager/manager.go
+++ b/pkg/jobmanager/manager.go
@@ -116,6 +116,9 @@ func cleanupCgroup(job *Job) error {
 
 	// The cgroup dir can only be deleted by rmdir syscall
 	if err := syscall.Rmdir(cgroupPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to remove cgroup directory %s: %v", cgroupPath, err)
 	}
 
@@ -151,18 +154,20 @@ func (m *JobManager) StartJob(command string, commandArgs []string, memoryLimit,
 
 	jobUUID, err := uuid.NewUUID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 		stdout.Close()
 		stderr.Close()
+		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 	}
 	jobID := jobUUID.String()
 
-	if err := setLimits(cmd.Process.Pid, jobID, cpuLimit, memoryLimit, writeBps, readBps); err != nil {
-		err := cmd.Process.Kill()
-		if err != nil {
-			return nil, err
+	if memoryLimit != "" || cpuLimit != "" || mount != "" || writeBps != "" || readBps != "" {
+		if err := setLimits(cmd.Process.Pid, jobID, cpuLimit, memoryLimit, writeBps, readBps); err != nil {
+			err := cmd.Process.Kill()
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("failed to set limits: %v", err)
 		}
-		return nil, fmt.Errorf("failed to set limits: %v", err)
 	}
 
 	job := &Job{

--- a/pkg/jobmanager/manager_test.go
+++ b/pkg/jobmanager/manager_test.go
@@ -1,0 +1,111 @@
+//go:build linux || darwin
+
+package jobmanager
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func skipWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX commands")
+	}
+}
+
+func TestNewReturnsManager(t *testing.T) {
+	if New() == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestStartJobNoLimitsCapturesOutputAndListsJob(t *testing.T) {
+	skipWindows(t)
+
+	manager := New()
+	job, err := manager.StartJob("/bin/echo", []string{"hello"}, "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("StartJob() error = %v", err)
+	}
+	defer job.Cmd.Wait()
+
+	if job.ID == "" {
+		t.Fatal("StartJob() returned job with empty ID")
+	}
+	if job.Command != "/bin/echo" {
+		t.Fatalf("job.Command = %q, want /bin/echo", job.Command)
+	}
+	if job.PID <= 0 {
+		t.Fatalf("job.PID = %d, want > 0", job.PID)
+	}
+
+	var stdout []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stdout, _, err = manager.GetJobOutput(job.ID)
+		if err != nil {
+			t.Fatalf("GetJobOutput() error = %v", err)
+		}
+		if strings.Contains(string(stdout), "hello") {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !strings.Contains(string(stdout), "hello") {
+		t.Fatalf("stdout = %q, want to contain hello", string(stdout))
+	}
+
+	jobs := manager.ListJobs()
+	for _, listed := range jobs {
+		if listed.ID == job.ID {
+			return
+		}
+	}
+	t.Fatalf("ListJobs() did not include job %s", job.ID)
+}
+
+func TestUnknownJobErrors(t *testing.T) {
+	manager := New()
+	unknownID := "missing-job"
+
+	if running, err := manager.GetJobStatus(unknownID); err == nil || running {
+		t.Fatalf("GetJobStatus(%q) = (%v, %v), want error and running=false", unknownID, running, err)
+	}
+	if err := manager.StopJob(unknownID); err == nil {
+		t.Fatalf("StopJob(%q) succeeded, want error", unknownID)
+	}
+	if err := manager.KillJob(unknownID); err == nil {
+		t.Fatalf("KillJob(%q) succeeded, want error", unknownID)
+	}
+	if stdout, stderr, err := manager.GetJobOutput(unknownID); err == nil || stdout != nil || stderr != nil {
+		t.Fatalf("GetJobOutput(%q) = (%q, %q, %v), want nil output and error", unknownID, stdout, stderr, err)
+	}
+	if err := manager.StreamOutput(context.Background(), unknownID, func([]byte, bool) error { return nil }); err == nil {
+		t.Fatalf("StreamOutput(%q) succeeded, want error", unknownID)
+	}
+}
+
+func TestGetJobStatusReturnsFalseAfterExit(t *testing.T) {
+	skipWindows(t)
+
+	manager := New()
+	job, err := manager.StartJob("/bin/sh", []string{"-c", "exit 0"}, "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("StartJob() error = %v", err)
+	}
+	if err := job.Cmd.Wait(); err != nil {
+		t.Fatalf("waiting for job exit: %v", err)
+	}
+
+	running, err := manager.GetJobStatus(job.ID)
+	if err != nil {
+		t.Fatalf("GetJobStatus() error = %v", err)
+	}
+	if running {
+		t.Fatal("GetJobStatus() running = true, want false after process exits")
+	}
+}


### PR DESCRIPTION
## Summary
- Skip cgroup setup when StartJob is called without limit inputs
- Add POSIX unit tests for jobmanager creation, no-limit start/output/listing, unknown job errors, and exited status
- Ignore missing cgroup directories during cleanup for no-limit jobs

## Validation
- GOOS=linux GOARCH=amd64 go build ./...
- GOOS=linux GOARCH=amd64 go vet ./...
- WSL Linux: go test -v -cover ./pkg/jobmanager/... (45.1%)