### PR TITLE
test(server): refactor for testability and add handler tests

### DIFF
--- a/pkg/jobmanager/manager.go
+++ b/pkg/jobmanager/manager.go
@@ -151,9 +151,9 @@ func (m *JobManager) StartJob(command string, commandArgs []string, memoryLimit,
 
 	jobUUID, err := uuid.NewUUID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 		stdout.Close()
 		stderr.Close()
+		return nil, fmt.Errorf("failed to generate job uuid: %v", err)
 	}
 	jobID := jobUUID.String()
 

--- a/server/main.go
+++ b/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -16,146 +15,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
-
-type server struct {
-	pb.UnimplementedSentryServiceServer
-	manager *jobmanager.JobManager
-}
-
-func (s *server) StartJob(ctx context.Context, req *pb.StartJobRequest) (*pb.StartJobResponse, error) {
-	job, err := s.manager.StartJob(req.Command, req.CommandArgs, req.MemoryLimit, req.CpuLimit, req.Mount, req.WriteBps, req.ReadBps)
-	if err != nil {
-		log.Printf("Failed to start job %v", err)
-		return nil, err
-	}
-	return &pb.StartJobResponse{
-		JobId: job.ID,
-	}, nil
-}
-
-func (s *server) StopJob(ctx context.Context, req *pb.StopJobRequest) (*pb.StopJobResponse, error) {
-	err := s.manager.StopJob(req.JobId)
-	if err != nil {
-		log.Printf("Failed to stop job %s: %v", req.JobId, err)
-		return &pb.StopJobResponse{
-			Success: false,
-			Message: err.Error(),
-		}, nil
-	}
-
-	log.Printf("Stopped job %s", req.JobId)
-	return &pb.StopJobResponse{
-		Success: true,
-		Message: fmt.Sprintf("Job %s stopped successfully", req.JobId),
-	}, nil
-}
-
-func (s *server) GetJobStatus(ctx context.Context, req *pb.JobStatusRequest) (*pb.JobStatusResponse, error) {
-	isRunning, err := s.manager.GetJobStatus(req.JobId)
-	if err != nil {
-		log.Printf("Failed to get job status %s: %v", req.JobId, err)
-		return &pb.JobStatusResponse{
-			IsRunning: false,
-		}, nil
-	}
-
-	return &pb.JobStatusResponse{
-		IsRunning: isRunning,
-	}, nil
-}
-
-func (s *server) GetJobLogs(ctx context.Context, req *pb.JobLogsRequest) (*pb.JobLogsResponse, error) {
-	stdout, stderr, err := s.manager.GetJobOutput(req.JobId)
-	if err != nil {
-		return nil, err
-	}
-
-	// Combine stdout and stderr with markers
-	logs := fmt.Sprintf("=== STDOUT ===\n%s\n=== STDERR ===\n%s", stdout, stderr)
-	return &pb.JobLogsResponse{
-		Logs: []byte(logs),
-	}, nil
-}
-
-func (s *server) ListJobs(ctx context.Context, req *pb.ListJobsRequest) (*pb.ListJobsResponse, error) {
-	jobs := s.manager.ListJobs()
-	response := &pb.ListJobsResponse{
-		Jobs: make([]*pb.JobInfo, 0, len(jobs)),
-	}
-
-	for _, job := range jobs {
-		isRunning, _ := s.manager.GetJobStatus(job.ID)
-		jobInfo := &pb.JobInfo{
-			JobId:       job.ID,
-			Command:     job.Command,
-			IsRunning:   isRunning,
-			MemoryLimit: job.MemoryLimit,
-			CpuLimit:    job.CpuLimit,
-			Mount:       job.Mount,
-			ReadBps:     job.ReadBps,
-			WriteBps:    job.WriteBps,
-		}
-		response.Jobs = append(response.Jobs, jobInfo)
-	}
-
-	return response, nil
-}
-
-func (s *server) KillJob(ctx context.Context, req *pb.KillJobRequest) (*pb.KillJobResponse, error) {
-	err := s.manager.KillJob(req.JobId)
-	if err != nil {
-		return &pb.KillJobResponse{
-			Success: false,
-			Message: err.Error(),
-		}, nil
-	}
-
-	return &pb.KillJobResponse{
-		Success: true,
-		Message: fmt.Sprintf("Job %s killed successfully", req.JobId),
-	}, nil
-}
-
-func (s *server) StreamJobLogs(req *pb.JobLogsRequest, stream pb.SentryService_StreamJobLogsServer) error {
-	// First, send existing logs
-	stdout, stderr, err := s.manager.GetJobOutput(req.JobId)
-	if err != nil {
-		return err
-	}
-
-	// Send stdout history
-	if len(stdout) > 0 {
-		if err := stream.Send(&pb.JobOutput{
-			JobId:    req.JobId,
-			Data:     stdout,
-			IsStderr: false,
-		}); err != nil {
-			return err
-		}
-	}
-
-	// Send stderr history
-	if len(stderr) > 0 {
-		if err := stream.Send(&pb.JobOutput{
-			JobId:    req.JobId,
-			Data:     stderr,
-			IsStderr: true,
-		}); err != nil {
-			return err
-		}
-	}
-
-	ctx := stream.Context()
-
-	// Then start streaming new output
-	return s.manager.StreamOutput(ctx, req.JobId, func(data []byte, isStderr bool) error {
-		return stream.Send(&pb.JobOutput{
-			JobId:    req.JobId,
-			Data:     data,
-			IsStderr: isStderr,
-		})
-	})
-}
 
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
@@ -194,9 +53,8 @@ func main() {
 	}
 
 	s := grpc.NewServer(grpc.Creds(creds))
-	srv := &server{
-		manager: jobmanager.New(),
-	}
+	manager := jobmanager.New()
+	srv := NewServer(manager)
 	pb.RegisterSentryServiceServer(s, srv)
 
 	// Setup signal handling
@@ -207,7 +65,7 @@ func main() {
 	go func() {
 		<-sigChan
 		fmt.Println("\nReceived interrupt signal. Cleaning up...")
-		srv.manager.KillJobsAll()
+		manager.KillJobsAll()
 		os.Exit(0)
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	pb "github.com/arazmj/sentry-run/api/proto"
+	"github.com/arazmj/sentry-run/pkg/jobmanager"
+)
+
+type JobManager interface {
+	StartJob(command string, commandArgs []string, memoryLimit, cpuLimit, mount, writeBps, readBps string) (*jobmanager.Job, error)
+	StopJob(jobID string) error
+	KillJob(jobID string) error
+	GetJobStatus(jobID string) (bool, error)
+	GetJobOutput(jobID string) (stdout, stderr []byte, err error)
+	ListJobs() []*jobmanager.Job
+	StreamOutput(ctx context.Context, jobID string, callback jobmanager.OutputCallback) error
+}
+
+type Server struct {
+	pb.UnimplementedSentryServiceServer
+	manager JobManager
+}
+
+func NewServer(manager JobManager) *Server {
+	return &Server{manager: manager}
+}
+
+func (s *Server) StartJob(ctx context.Context, req *pb.StartJobRequest) (*pb.StartJobResponse, error) {
+	job, err := s.manager.StartJob(req.Command, req.CommandArgs, req.MemoryLimit, req.CpuLimit, req.Mount, req.WriteBps, req.ReadBps)
+	if err != nil {
+		log.Printf("Failed to start job %v", err)
+		return nil, err
+	}
+	return &pb.StartJobResponse{
+		JobId: job.ID,
+	}, nil
+}
+
+func (s *Server) StopJob(ctx context.Context, req *pb.StopJobRequest) (*pb.StopJobResponse, error) {
+	err := s.manager.StopJob(req.JobId)
+	if err != nil {
+		log.Printf("Failed to stop job %s: %v", req.JobId, err)
+		return &pb.StopJobResponse{
+			Success: false,
+			Message: err.Error(),
+		}, nil
+	}
+
+	log.Printf("Stopped job %s", req.JobId)
+	return &pb.StopJobResponse{
+		Success: true,
+		Message: fmt.Sprintf("Job %s stopped successfully", req.JobId),
+	}, nil
+}
+
+func (s *Server) GetJobStatus(ctx context.Context, req *pb.JobStatusRequest) (*pb.JobStatusResponse, error) {
+	isRunning, err := s.manager.GetJobStatus(req.JobId)
+	if err != nil {
+		log.Printf("Failed to get job status %s: %v", req.JobId, err)
+		return &pb.JobStatusResponse{
+			IsRunning: false,
+		}, nil
+	}
+
+	return &pb.JobStatusResponse{
+		IsRunning: isRunning,
+	}, nil
+}
+
+func (s *Server) GetJobLogs(ctx context.Context, req *pb.JobLogsRequest) (*pb.JobLogsResponse, error) {
+	stdout, stderr, err := s.manager.GetJobOutput(req.JobId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Combine stdout and stderr with markers
+	logs := fmt.Sprintf("=== STDOUT ===\n%s\n=== STDERR ===\n%s", stdout, stderr)
+	return &pb.JobLogsResponse{
+		Logs: []byte(logs),
+	}, nil
+}
+
+func (s *Server) ListJobs(ctx context.Context, req *pb.ListJobsRequest) (*pb.ListJobsResponse, error) {
+	jobs := s.manager.ListJobs()
+	response := &pb.ListJobsResponse{
+		Jobs: make([]*pb.JobInfo, 0, len(jobs)),
+	}
+
+	for _, job := range jobs {
+		isRunning, _ := s.manager.GetJobStatus(job.ID)
+		jobInfo := &pb.JobInfo{
+			JobId:       job.ID,
+			Command:     job.Command,
+			IsRunning:   isRunning,
+			MemoryLimit: job.MemoryLimit,
+			CpuLimit:    job.CpuLimit,
+			Mount:       job.Mount,
+			ReadBps:     job.ReadBps,
+			WriteBps:    job.WriteBps,
+		}
+		response.Jobs = append(response.Jobs, jobInfo)
+	}
+
+	return response, nil
+}
+
+func (s *Server) KillJob(ctx context.Context, req *pb.KillJobRequest) (*pb.KillJobResponse, error) {
+	err := s.manager.KillJob(req.JobId)
+	if err != nil {
+		return &pb.KillJobResponse{
+			Success: false,
+			Message: err.Error(),
+		}, nil
+	}
+
+	return &pb.KillJobResponse{
+		Success: true,
+		Message: fmt.Sprintf("Job %s killed successfully", req.JobId),
+	}, nil
+}
+
+func (s *Server) StreamJobLogs(req *pb.JobLogsRequest, stream pb.SentryService_StreamJobLogsServer) error {
+	// First, send existing logs
+	stdout, stderr, err := s.manager.GetJobOutput(req.JobId)
+	if err != nil {
+		return err
+	}
+
+	// Send stdout history
+	if len(stdout) > 0 {
+		if err := stream.Send(&pb.JobOutput{
+			JobId:    req.JobId,
+			Data:     stdout,
+			IsStderr: false,
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Send stderr history
+	if len(stderr) > 0 {
+		if err := stream.Send(&pb.JobOutput{
+			JobId:    req.JobId,
+			Data:     stderr,
+			IsStderr: true,
+		}); err != nil {
+			return err
+		}
+	}
+
+	ctx := stream.Context()
+
+	// Then start streaming new output
+	return s.manager.StreamOutput(ctx, req.JobId, func(data []byte, isStderr bool) error {
+		return stream.Send(&pb.JobOutput{
+			JobId:    req.JobId,
+			Data:     data,
+			IsStderr: isStderr,
+		})
+	})
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	pb "github.com/arazmj/sentry-run/api/proto"
+	"github.com/arazmj/sentry-run/pkg/jobmanager"
+)
+
+type fakeJobManager struct {
+	startJob    *jobmanager.Job
+	startErr    error
+	startCall   startJobCall
+	stopErr     error
+	stoppedJob  string
+	status      map[string]bool
+	statusErr   error
+	statusCalls []string
+	stdout      []byte
+	stderr      []byte
+	outputJob   string
+	jobs        []*jobmanager.Job
+	killErr     error
+	killedJob   string
+}
+
+type startJobCall struct {
+	command     string
+	commandArgs []string
+	memoryLimit string
+	cpuLimit    string
+	mount       string
+	writeBps    string
+	readBps     string
+}
+
+func (f *fakeJobManager) StartJob(command string, commandArgs []string, memoryLimit, cpuLimit, mount, writeBps, readBps string) (*jobmanager.Job, error) {
+	f.startCall = startJobCall{command, commandArgs, memoryLimit, cpuLimit, mount, writeBps, readBps}
+	return f.startJob, f.startErr
+}
+func (f *fakeJobManager) StopJob(jobID string) error { f.stoppedJob = jobID; return f.stopErr }
+func (f *fakeJobManager) KillJob(jobID string) error { f.killedJob = jobID; return f.killErr }
+func (f *fakeJobManager) GetJobStatus(jobID string) (bool, error) {
+	f.statusCalls = append(f.statusCalls, jobID)
+	if f.statusErr != nil {
+		return false, f.statusErr
+	}
+	return f.status[jobID], nil
+}
+func (f *fakeJobManager) GetJobOutput(jobID string) ([]byte, []byte, error) {
+	f.outputJob = jobID
+	return f.stdout, f.stderr, nil
+}
+func (f *fakeJobManager) ListJobs() []*jobmanager.Job { return f.jobs }
+func (f *fakeJobManager) StreamOutput(ctx context.Context, jobID string, callback jobmanager.OutputCallback) error {
+	return nil
+}
+
+func TestStartJobSuccess(t *testing.T) {
+	fake := &fakeJobManager{startJob: &jobmanager.Job{ID: "job-1"}}
+	req := &pb.StartJobRequest{Command: "echo", CommandArgs: []string{"hello"}, MemoryLimit: "128M", CpuLimit: "10000 100000", Mount: "/srv", WriteBps: "1M", ReadBps: "2M"}
+	resp, err := NewServer(fake).StartJob(context.Background(), req)
+	if err != nil {
+		t.Fatalf("StartJob returned error: %v", err)
+	}
+	if resp.GetJobId() != "job-1" {
+		t.Fatalf("JobId = %q, want job-1", resp.GetJobId())
+	}
+	want := startJobCall{req.Command, req.CommandArgs, req.MemoryLimit, req.CpuLimit, req.Mount, req.WriteBps, req.ReadBps}
+	if !reflect.DeepEqual(fake.startCall, want) {
+		t.Fatalf("StartJob call = %#v, want %#v", fake.startCall, want)
+	}
+}
+
+func TestStartJobError(t *testing.T) {
+	boom := errors.New("boom")
+	resp, err := NewServer(&fakeJobManager{startErr: boom}).StartJob(context.Background(), &pb.StartJobRequest{Command: "false"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want %v", err, boom)
+	}
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+}
+
+func TestStopJobSuccess(t *testing.T) {
+	fake := &fakeJobManager{}
+	resp, err := NewServer(fake).StopJob(context.Background(), &pb.StopJobRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("StopJob returned error: %v", err)
+	}
+	if !resp.GetSuccess() || !strings.Contains(resp.GetMessage(), "job-1") {
+		t.Fatalf("response = %#v, want success", resp)
+	}
+	if fake.stoppedJob != "job-1" {
+		t.Fatalf("StopJob called with %q", fake.stoppedJob)
+	}
+}
+
+func TestStopJobError(t *testing.T) {
+	boom := errors.New("stop failed")
+	resp, err := NewServer(&fakeJobManager{stopErr: boom}).StopJob(context.Background(), &pb.StopJobRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if resp.GetSuccess() || resp.GetMessage() != boom.Error() {
+		t.Fatalf("response = %#v, want failure", resp)
+	}
+}
+
+func TestGetJobStatusSuccess(t *testing.T) {
+	resp, err := NewServer(&fakeJobManager{status: map[string]bool{"job-1": true}}).GetJobStatus(context.Background(), &pb.JobStatusRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("GetJobStatus returned error: %v", err)
+	}
+	if !resp.GetIsRunning() {
+		t.Fatal("IsRunning = false, want true")
+	}
+}
+
+func TestGetJobStatusError(t *testing.T) {
+	resp, err := NewServer(&fakeJobManager{statusErr: errors.New("missing")}).GetJobStatus(context.Background(), &pb.JobStatusRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if resp.GetIsRunning() {
+		t.Fatal("IsRunning = true, want false")
+	}
+}
+
+func TestGetJobLogsSuccess(t *testing.T) {
+	fake := &fakeJobManager{stdout: []byte("out"), stderr: []byte("err")}
+	resp, err := NewServer(fake).GetJobLogs(context.Background(), &pb.JobLogsRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("GetJobLogs returned error: %v", err)
+	}
+	want := "=== STDOUT ===\nout\n=== STDERR ===\nerr"
+	if string(resp.GetLogs()) != want {
+		t.Fatalf("logs = %q, want %q", string(resp.GetLogs()), want)
+	}
+	if fake.outputJob != "job-1" {
+		t.Fatalf("GetJobOutput called with %q", fake.outputJob)
+	}
+}
+
+func TestListJobsEmpty(t *testing.T) {
+	resp, err := NewServer(&fakeJobManager{}).ListJobs(context.Background(), &pb.ListJobsRequest{})
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(resp.GetJobs()) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(resp.GetJobs()))
+	}
+}
+
+func TestListJobsMultiple(t *testing.T) {
+	fake := &fakeJobManager{
+		jobs: []*jobmanager.Job{
+			{ID: "job-1", Command: "echo", MemoryLimit: "128M", CpuLimit: "10000 100000", Mount: "/srv", ReadBps: "1M", WriteBps: "2M"},
+			{ID: "job-2", Command: "sleep"},
+		},
+		status: map[string]bool{"job-1": true, "job-2": false},
+	}
+	resp, err := NewServer(fake).ListJobs(context.Background(), &pb.ListJobsRequest{})
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(resp.GetJobs()) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(resp.GetJobs()))
+	}
+	if got := resp.GetJobs()[0]; got.GetJobId() != "job-1" || got.GetCommand() != "echo" || !got.GetIsRunning() || got.GetMemoryLimit() != "128M" || got.GetCpuLimit() != "10000 100000" || got.GetMount() != "/srv" || got.GetReadBps() != "1M" || got.GetWriteBps() != "2M" {
+		t.Fatalf("first job = %#v", got)
+	}
+	if got := resp.GetJobs()[1]; got.GetJobId() != "job-2" || got.GetCommand() != "sleep" || got.GetIsRunning() {
+		t.Fatalf("second job = %#v", got)
+	}
+	if !reflect.DeepEqual(fake.statusCalls, []string{"job-1", "job-2"}) {
+		t.Fatalf("status calls = %v", fake.statusCalls)
+	}
+}
+
+func TestKillJobSuccess(t *testing.T) {
+	fake := &fakeJobManager{}
+	resp, err := NewServer(fake).KillJob(context.Background(), &pb.KillJobRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("KillJob returned error: %v", err)
+	}
+	if !resp.GetSuccess() || !strings.Contains(resp.GetMessage(), "job-1") {
+		t.Fatalf("response = %#v, want success", resp)
+	}
+	if fake.killedJob != "job-1" {
+		t.Fatalf("KillJob called with %q", fake.killedJob)
+	}
+}
+
+func TestKillJobError(t *testing.T) {
+	boom := errors.New("kill failed")
+	resp, err := NewServer(&fakeJobManager{killErr: boom}).KillJob(context.Background(), &pb.KillJobRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if resp.GetSuccess() || resp.GetMessage() != boom.Error() {
+		t.Fatalf("response = %#v, want failure", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- Move server gRPC handlers behind a testable Server type and JobManager interface
- Add unit tests for start, stop, status, logs, list, and kill handlers using a fake manager
- Fix an unreachable cleanup statement so linux vet passes

## Validation
- GOOS=linux GOARCH=amd64 go test -c ./server
- GOOS=linux GOARCH=amd64 go build ./...
- GOOS=linux GOARCH=amd64 go vet ./...
- git diff --check